### PR TITLE
Add dark theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
+# Portfolio Site
 
-# codexpractice
+This project is a simple React + TypeScript portfolio built with Next.js. You can deploy it easily to Vercel.
 
-This is my React + TypeScript portfolio project.
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+
+2. Run the development server
+   ```bash
+   npm run dev
+   ```
+
+3. Build for production
+   ```bash
+   npm run build
+   ```
+
+## Pages
+
+- `/` - Landing page
+- `/about` - About me
+- `/blog` - Blog entries (stored in `localStorage`)
+- `/portfolio` - Portfolio entries (stored in `localStorage`)
+- `/contact` - Contact information
+- `/dev` - Developer page to add blog/portfolio entries
+
+Entries you add via `/dev` will be saved to your browser's `localStorage`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "portfolio-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.7",
+    "@types/node": "20.11.30",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3"
+  }
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,27 @@
+export default function About() {
+  return (
+    <div>
+      <h1>なにもの？</h1>
+      <p>情報系学部の3年生です。Web,アプリ,ゲームなど作ったりしています。</p>
+      <p>登山、キャンプ、旅行もそこそこ好きです。</p>
+      <section>
+        <h2>学歴</h2>
+        <ul>
+          <li>2010 月小学校</li>
+          <li>2016 月中学校</li>
+          <li>2019 羊羹高校</li>
+          <li>2022 宮崎大学大学工学部 工学科 情報通信工学プログラム</li>
+        </ul>
+      </section>
+      <section>
+        <h2>職歴</h2>
+        <ul>
+          <li>2022 smolt</li>
+          <li>2023 ラウンドワン</li>
+          <li>2024 wowd</li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Entry {
+  title: string;
+  content: string;
+}
+
+export default function Blog() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    const saved = JSON.parse(localStorage.getItem('blog-entries') || '[]') as Entry[];
+    setEntries(saved);
+  }, []);
+
+  return (
+    <div>
+      <h1>Blog</h1>
+      {entries.map((e, i) => (
+        <article key={i}>
+          <h3>{e.title}</h3>
+          <p>{e.content}</p>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function Contact() {
+  return (
+    <div>
+      <h1>Contact</h1>
+      <p>You can reach me at example@example.com.</p>
+    </div>
+  );
+}

--- a/src/app/dev/page.tsx
+++ b/src/app/dev/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import PostForm from '../../components/PostForm';
+
+export default function DevPage() {
+  return (
+    <div>
+      <h1>Developer Page</h1>
+      <PostForm type="blog" />
+      <PostForm type="portfolio" />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,125 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+
+:root {
+  --nav-height: 60px;
+  --bg-color: #ffffff;
+  --nav-bg: #0a1d2e;
+  --text-color: #222222;
+  --link-color: #0a84ff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-color: #121212;
+    --nav-bg: #001a30;
+    --text-color: #f0f0f0;
+    --link-color: #4dabff;
+  }
+}
+
+[data-theme='light'] {
+  --bg-color: #ffffff;
+  --nav-bg: #0a1d2e;
+  --text-color: #222222;
+  --link-color: #0a84ff;
+}
+
+[data-theme='dark'] {
+  --bg-color: #121212;
+  --nav-bg: #001a30;
+  --text-color: #f0f0f0;
+  --link-color: #4dabff;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 0;
+  padding: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+nav {
+  background: var(--nav-bg);
+  color: white;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: var(--nav-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  z-index: 1000;
+}
+
+nav a {
+  color: white;
+  text-decoration: none;
+  transition: opacity 0.3s ease;
+}
+
+nav a:hover {
+  opacity: 0.7;
+}
+
+main {
+  padding: 2rem 1rem;
+  margin-top: var(--nav-height);
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1.5rem 0;
+  font-size: 0.875rem;
+  border-top: 1px solid #ddd;
+  background: var(--bg-color);
+}
+
+.post-form {
+  margin-bottom: 2rem;
+}
+
+.form-field {
+  margin-bottom: 0.5rem;
+  display: block;
+}
+
+input,
+textarea {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  background: var(--link-color);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+}
+
+button:hover {
+  opacity: 0.8;
+}
+
+@media (max-width: 600px) {
+  nav {
+    flex-wrap: wrap;
+    padding: 0 1rem;
+    justify-content: space-around;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import Layout from '../components/Layout';
+
+export const metadata = {
+  title: 'My Portfolio',
+  description: 'Personal website',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ja">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
+      <body>
+        <Layout>{children}</Layout>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,30 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>霧島 Website</h1>
+      <section>
+        <h2>なにもの？</h2>
+        <p>情報系学部の3年生です。Web,アプリ,ゲームなど作ったりしています。</p>
+        <p>登山、キャンプ、旅行もそこそこ好きです。</p>
+      </section>
+      <section>
+        <h2>学歴</h2>
+        <ul>
+          <li>2010 月小学校</li>
+          <li>2016 月中学校</li>
+          <li>2019 羊羹高校</li>
+          <li>2022 宮崎大学大学工学部 工学科 情報通信工学プログラム</li>
+        </ul>
+      </section>
+      <section>
+        <h2>職歴</h2>
+        <ul>
+          <li>2022 smolt</li>
+          <li>2023 ラウンドワン</li>
+          <li>2024 wowd</li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Entry {
+  title: string;
+  content: string;
+}
+
+export default function Portfolio() {
+  const [entries, setEntries] = useState<Entry[]>([]);
+
+  useEffect(() => {
+    const saved = JSON.parse(localStorage.getItem('portfolio-entries') || '[]') as Entry[];
+    setEntries(saved);
+  }, []);
+
+  return (
+    <div>
+      <h1>Portfolio</h1>
+      {entries.map((e, i) => (
+        <section key={i}>
+          <h3>{e.title}</h3>
+          <p>{e.content}</p>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const Layout = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<'light' | 'dark'>();
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initial = stored || (prefersDark ? 'dark' : 'light');
+    setTheme(initial);
+    document.documentElement.dataset.theme = initial;
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(newTheme);
+    localStorage.setItem('theme', newTheme);
+    document.documentElement.dataset.theme = newTheme;
+  };
+
+  return (
+    <div>
+      <nav>
+        <Link href="/">Home</Link>
+        <Link href="/about">About</Link>
+        <Link href="/blog">Blog</Link>
+        <Link href="/portfolio">Portfolio</Link>
+        <Link href="/contact">Contact</Link>
+        <Link href="/dev">Dev</Link>
+        <button onClick={toggleTheme} aria-label="Toggle theme">
+          {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
+      </nav>
+      <main>{children}</main>
+      <footer>© 2025 My Website. All rights reserved.</footer>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/components/PostForm.tsx
+++ b/src/components/PostForm.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface Entry {
+  title: string;
+  content: string;
+}
+
+const PostForm = ({ type }: { type: 'blog' | 'portfolio' }) => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleSubmit = () => {
+    const key = `${type}-entries`;
+    const existing = JSON.parse(localStorage.getItem(key) || '[]') as Entry[];
+    existing.push({ title, content });
+    localStorage.setItem(key, JSON.stringify(existing));
+    setTitle('');
+    setContent('');
+    alert('Saved!');
+  };
+
+  return (
+    <div className="post-form">
+      <h3>Add {type} entry</h3>
+      <div className="form-field">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="title"
+        />
+      </div>
+      <div className="form-field">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="content"
+        />
+      </div>
+      <button onClick={handleSubmit}>Save</button>
+    </div>
+  );
+};
+
+export default PostForm;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- enable theme switching in `Layout` using a client-side button
- define dark theme variables and system preference in global CSS

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68426dadd334832985f03aaa07907741